### PR TITLE
Set y offset for staff text

### DIFF
--- a/AngloTab.qml
+++ b/AngloTab.qml
@@ -123,6 +123,7 @@ MuseScore {
             text.placement = placement
             text.align = Align.BASELINE | Align.HCENTER
             text.offsetX = 0.7
+            text.offsetY = (placement == Placement.ABOVE) ? -2.5 : 3.5
             cursor.add(text)
         }
         curScore.endCmd()


### PR DESCRIPTION
I decided that rather than try to keep vertical alignment consistent across the entire score (which may produce odd results if there's a single line with a very high or low note), it made more sense to just set a default offset and let auto-positioning deal with the rest. This will have to be revisited when switching from staff text to lines for tablature. Closes #3 (for now).